### PR TITLE
Call to undefined method [package]

### DIFF
--- a/src/RyanNielson/Meta/MetaServiceProvider.php
+++ b/src/RyanNielson/Meta/MetaServiceProvider.php
@@ -12,16 +12,6 @@ class MetaServiceProvider extends ServiceProvider {
     protected $defer = false;
 
     /**
-     * Bootstrap the application events.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        $this->package('ryannielson/meta');
-    }
-
-    /**
      * Register the service provider.
      *
      * @return void


### PR DESCRIPTION
It seems that service providers no longer have a `package` method in Laravel 5. Since this package doesn't feature any views, translations or special configuration, we could skip the boot method entirely.

The code in this PR works for me (tested with Laravel 5.0.13). You may want to create a 4.3 branch for folks that still use Laravel 4.3. [Intervention/image](https://github.com/Intervention/image) has done a good job switching internally between 4.3 and 5, here's their code, for reference:
https://github.com/Intervention/image/blob/master/src/Intervention/Image/ImageServiceProvider.php

More on this issue here:
https://medium.com/@morrislaptop/bridging-laravel-4-packages-to-laravel-5-2081f19643c6
https://laracasts.com/discuss/channels/general-discussion/l5-latest-commit-breaks-if-using-waygenerators-or-image-internvention