### PR TITLE
Make `fb:` prefixes use property not name

### DIFF
--- a/src/RyanNielson/Meta/Meta.php
+++ b/src/RyanNielson/Meta/Meta.php
@@ -134,7 +134,7 @@ class Meta {
      */
     private function metaTag($name, $content)
     {
-        if(substr($name, 0, 3) == 'og:')
+        if(substr($name, 0, 3) == 'og:' || substr($name, 0, 3) == 'fb:')
             return "<meta property=\"$name\" content=\"$content\"/>";
         else
             return "<meta name=\"$name\" content=\"$content\"/>";


### PR DESCRIPTION
Similar to PR #4. Makes `fb:*` properties (namely `fb:app_id`) use the `property` attribute instead of `name`.